### PR TITLE
Add pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,3 @@
+pkgconfig_DATA = mustache_c-1.0.pc
+
 SUBDIRS = src . test

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 AC_PREREQ(2.61)
-AC_INIT([mustashe_c], [1.0.0], [x86mail@gmail.com])
+AC_INIT([mustache_c], [1.0.0], [x86mail@gmail.com])
 
+AC_CONFIG_FILES([mustache_c-1.0.pc])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build])
@@ -11,6 +12,9 @@ AC_PROG_CC
 AC_PROG_LIBTOOL
 AC_HEADER_STDC
 AC_FUNC_MALLOC
+
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
 
 AC_PATH_PROGS(BISON, [bison], no)
 AC_PATH_PROGS(FLEX, [flex], no)

--- a/mustache_c-1.0.pc.in
+++ b/mustache_c-1.0.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: Mustache implementation in pure C
+URL: https://github.com/x86-64/mustache-c
+Version: @VERSION@
+Libs: -lmustache_c -L${libdir}
+Cflags: -I${includedir}


### PR DESCRIPTION
First we fix a typo in the configure.ac and then provide a package config (.pc) file for mustache_c. This way everyone (especially cmake) can pick mustache_c more easily.

You have to run `autoreconf -i` to regenerate all the autoconf stuff. But I leave this to you.
