### PR TITLE
Make header file self contained

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,10 @@ AC_FUNC_MALLOC
 AC_PATH_PROGS(BISON, [bison], no)
 AC_PATH_PROGS(FLEX, [flex], no)
 
+AC_CHECK_HEADER([stdint.h], [],
+[AC_MSG_ERROR([Couldn't find or include stdint.h])],
+[])
+
 AC_ARG_ENABLE(debug,  AS_HELP_STRING([--enable-debug],  [compile with debug functions]))
 if test "x$enable_debug" == "xyes"; then
         AC_DEFINE([DEBUG], [1], [Defined if debug functions requested])

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -1,6 +1,8 @@
 #ifndef MUSTACHE_H
 #define MUSTACHE_H
 
+#include <stdint.h>
+
 /** @file mustache.h */
 
 typedef struct mustache_api_t             mustache_api_t;                ///< Api typedef


### PR DESCRIPTION
The header file for mustache_c is sadly not self contained. One has to include `stdint.h` before including `mustache.h` or one would get compiler errors.

This adds `stdint.h` to `mustache.h` and also adds an explicit check to autconf. Again `autoreconf -i` is required to regenerate the autoconf files.
