### PR TITLE
Allow dash in variable names

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 GENSOURCE = parser.tab.h parser.tab.c parser.lex.c
 
 lib_LTLIBRARIES=libmustache_c.la
-libmustache_c_la_SOURCES= $(GENSOURCE)
+libmustache_c_la_SOURCES= $(GENSOURCE) mustache-internal.h
 libmustache_c_la_LDFLAGS= -module -avoid-version -shared
 EXTRA_DIST = parser.l parser.y                 
 CLEANFILES = $(GENSOURCE)

--- a/src/mustache-internal.h
+++ b/src/mustache-internal.h
@@ -1,0 +1,10 @@
+#ifndef MUSTACHEC_INTERNAL_H
+#define MUSTACHEC_INTERNAL_H
+
+typedef struct mustache_ctx {
+	mustache_api_t        *api;
+	mustache_template_t   *template;
+	void                  *userdata;
+} mustache_ctx;
+
+#endif

--- a/src/parser.l
+++ b/src/parser.l
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include "config.h"
 #include "mustache.h"
+#include "mustache-internal.h"
 #include "parser.tab.h"
 %}
 

--- a/src/parser.l
+++ b/src/parser.l
@@ -14,7 +14,7 @@
 %x comment
 %x mustag
 
-name        [a-z0-9][a-z0-9_:]*
+name        [a-z0-9][a-z0-9_:-]*
 special     [#^/]
 
 %%

--- a/src/parser.y
+++ b/src/parser.y
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <config.h>
 #include <mustache.h>
+#include <mustache-internal.h>
 #include <parser.tab.h>	
 
 #define YY_END_OF_BUFFER_CHAR 0
@@ -13,12 +14,6 @@ typedef size_t yy_size_t;
 extern YY_BUFFER_STATE mustache_p__scan_buffer (char *base,yy_size_t size  );
 extern int mustache_p_lex_destroy(void);
 extern int mustache_p_get_lineno(void);
-
-typedef struct mustache_ctx {
-	mustache_api_t        *api;
-	mustache_template_t   *template;
-	void                  *userdata;
-} mustache_ctx;
 
 void yyerror (mustache_ctx *, const char *);
 


### PR DESCRIPTION
This change allows variables to contain dashes. Such as `{{maximum-length}}` or `{{carry-capacity}}`.

It also moves the internals of mustache-c around, as newer bison/flex programs complained about not finding `mustache_ctx`. This structure has been moved into an internal header file which is included in all required places.
