### PR TITLE
Add examples

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 pkgconfig_DATA = mustache_c-1.0.pc
 
-SUBDIRS = src . test
+SUBDIRS = src . test examples

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,8 @@ if test "x$enable_helpers" != "xyes"; then
 fi
 
 AC_CONFIG_FILES([Makefile
-		src/Makefile
-		test/Makefile
+        src/Makefile
+        test/Makefile
+        examples/Makefile
 ])
 AC_OUTPUT

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,0 +1,9 @@
+noinst_PROGRAMS     = simple array
+
+simple_CFLAGS       = -I$(top_srcdir)/src/
+simple_SOURCES      = simple.c
+simple_LDADD        = $(top_srcdir)/src/libmustache_c.la
+
+array_CFLAGS        = -I$(top_srcdir)/src/
+array_SOURCES       = array.c
+array_LDADD         = $(top_srcdir)/src/libmustache_c.la

--- a/examples/array.c
+++ b/examples/array.c
@@ -1,0 +1,149 @@
+/* This simple example reads the file "array.template" from the current
+ * directory and replaces the section with an array of names. It shows on
+ * how to deal with sections that are actually arrays.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#include <mustache.h>
+
+static FILE *template = NULL;
+
+static char *names[] =
+{
+    "Angus McFife",
+    "Hootsman",
+    "Ser Proletius",
+    "Zargothrax",
+    "Ralathor",
+    NULL,
+};
+
+static uintmax_t
+mustache_read_file(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+{
+    /* Do whatever needs to be done to get sz number of bytes into buf.
+     */
+    return fread(buf, sizeof(char), sz, template);
+}
+
+static uintmax_t
+mustache_write_stdout(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+{
+    /* Do whatever it takes to write sz number of bytes from buf to somewhere.
+     */
+    return fwrite(buf, sizeof(char), sz, stdout);
+}
+
+static uintmax_t
+mustache_write_null(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+{
+    /* Fake success
+     */
+    return sz;
+}
+
+static void
+mustache_error(mustache_api_t *api, void *data, uintmax_t line, char *error)
+{
+    fprintf(stderr, "error in template: %" PRIu64  ": %s\n", line, error);
+}
+
+static uintmax_t
+mustache_sectget(mustache_api_t *api, void *data, mustache_token_section_t *s)
+{
+    if (strcmp(s->name, "members") == 0) {
+        /* To resolve an array, repeatedly call mustache_render() on the
+         * section but pass different user defined data. The user defined
+         * data should point to one item of the array.
+         */
+        char **name = names;
+
+        for (; *name; name++) {
+            if (!mustache_render(api, *name, s->section)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+static uintmax_t
+mustache_varget(mustache_api_t *api, void *data, mustache_token_variable_t *t)
+{
+    if (strcmp(t->text, "name") == 0) {
+        char *name = (char*)data;
+
+        if (name == NULL) {
+            fprintf(stderr, "error: name requested but not passed\n");
+            return false;
+        }
+
+        api->write(api, data, (char*)name, strlen(name));
+        return true;
+    }
+
+    fprintf(stderr, "error: unknown variable: %s\n", t->text);
+    /* If you return false, parsing will stop. To ignore unknown variables
+     * you should always return true.
+     */
+
+    return false;
+}
+
+int main(int ac, char **av)
+{
+    mustache_api_t api;
+    mustache_template_t *t = NULL;
+
+    template = fopen("array.template", "r");
+    if (template == NULL) {
+        fprintf(stderr, "error: failed to open file array.template: %s\n",
+                strerror(errno)
+            );
+        return 2;
+    }
+
+    api.read = mustache_read_file;
+    api.write = NULL;
+    api.error = mustache_error;
+    api.sectget = mustache_sectget;
+    api.varget = mustache_varget;
+
+    t = mustache_compile(&api, NULL);
+    if (t == NULL) {
+        fclose(template);
+        return 3;
+    }
+
+    /* Prerender also calls sectget() and varget() handlers. If you
+     * call api->write() in those handlers then stuff is written which
+     * you might not want. One way to circumvent that is to have a null
+     * writer.
+     */
+    api.write = mustache_write_null;
+    if (!mustache_prerender(&api, NULL, t)) {
+        fclose(template);
+        return 3;
+    }
+
+    /* And then set the proper writer on the actual render call.
+     */
+    api.write = mustache_write_stdout;
+    if (!mustache_render(&api, NULL, t)) {
+        fclose(template);
+        return 3;
+    }
+
+    fclose(template);
+
+    return 0;
+}

--- a/examples/array.template
+++ b/examples/array.template
@@ -1,0 +1,3 @@
+Members:
+{{#members}}  - {{name}}
+{{/members}}

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,0 +1,101 @@
+/* This simple example reads the file "simple.template" from the current
+ * directory and replaces the variable "name" with a self defined string.
+ * It shows basic usage of the mustache-c API.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#include <mustache.h>
+
+static FILE *template = NULL;
+
+static uintmax_t
+mustache_read_file(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+{
+    /* Do whatever needs to be done to get sz number of bytes into buf.
+     */
+    return fread(buf, sizeof(char), sz, template);
+}
+
+static uintmax_t
+mustache_write_stdout(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+{
+    /* Do whatever it takes to write sz number of bytes from buf to somewhere.
+     */
+    return fwrite(buf, sizeof(char), sz, stdout);
+}
+
+static void
+mustache_error(mustache_api_t *api, void *data, uintmax_t line, char *error)
+{
+    fprintf(stderr, "error in template: %" PRIu64  ": %s\n", line, error);
+}
+
+static uintmax_t
+mustache_sectget(mustache_api_t *api, void *data, mustache_token_section_t *s)
+{
+    /* Compare to s->name and do section related stuff. This usually revolves
+     * around calling mustache_render() again on the section itself.
+     *
+     * See array.c for an example on how to handle arrays.
+     */
+    return mustache_render(api, data, s->section);
+}
+
+static uintmax_t
+mustache_varget(mustache_api_t *api, void *data, mustache_token_variable_t *t)
+{
+    static const char *name = "Angus McFife";
+
+    if (strcmp(t->text, "name") == 0) {
+        api->write(api, data, (char*)name, strlen(name));
+        return true;
+    }
+
+    fprintf(stderr, "error: unknown variable: %s\n", t->text);
+    /* If you return false, parsing will stop. To ignore unknown variables
+     * you should always return true.
+     */
+
+    return false;
+}
+
+int main(int ac, char **av)
+{
+    mustache_api_t api;
+    mustache_template_t *t = NULL;
+
+    template = fopen("simple.template", "r");
+    if (template == NULL) {
+        fprintf(stderr, "error: failed to open file simple.template: %s\n",
+                strerror(errno)
+            );
+        return 2;
+    }
+
+    api.read = mustache_read_file;
+    api.write = mustache_write_stdout;
+    api.error = mustache_error;
+    api.sectget = mustache_sectget;
+    api.varget = mustache_varget;
+
+    t = mustache_compile(&api, NULL);
+    if (t == NULL) {
+        fclose(template);
+        return 3;
+    }
+
+    if (!mustache_render(&api, NULL, t)) {
+        fclose(template);
+        return 3;
+    }
+
+    fclose(template);
+
+    return 0;
+}

--- a/examples/simple.template
+++ b/examples/simple.template
@@ -1,0 +1,1 @@
+Hello World to {{name}}!


### PR DESCRIPTION
This adds two examples that show how to use the API. One is a simple test case with one variable. And the other shows how to resolve sections as arrays of multiple values. They are automatically built as well.

They built fine and are decently documented. This, and the updated read me should close issue #1.
