### PR TITLE
Make API const aware

### DIFF
--- a/examples/array.c
+++ b/examples/array.c
@@ -33,7 +33,8 @@ mustache_read_file(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
 }
 
 static uintmax_t
-mustache_write_stdout(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+mustache_write_stdout(mustache_api_t *api, void *data,
+                      char const *buf, uintmax_t sz)
 {
     /* Do whatever it takes to write sz number of bytes from buf to somewhere.
      */
@@ -41,7 +42,8 @@ mustache_write_stdout(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
 }
 
 static uintmax_t
-mustache_write_null(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+mustache_write_null(mustache_api_t *api, void *data,
+                    char const *buf, uintmax_t sz)
 {
     /* Fake success
      */
@@ -49,7 +51,8 @@ mustache_write_null(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
 }
 
 static void
-mustache_error(mustache_api_t *api, void *data, uintmax_t line, char *error)
+mustache_error(mustache_api_t *api, void *data,
+               uintmax_t line, char const *error)
 {
     fprintf(stderr, "error in template: %" PRIu64  ": %s\n", line, error);
 }

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -23,7 +23,8 @@ mustache_read_file(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
 }
 
 static uintmax_t
-mustache_write_stdout(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
+mustache_write_stdout(mustache_api_t *api, void *data,
+                      char const *buf, uintmax_t sz)
 {
     /* Do whatever it takes to write sz number of bytes from buf to somewhere.
      */
@@ -31,7 +32,8 @@ mustache_write_stdout(mustache_api_t *api, void *data, char *buf, uintmax_t sz)
 }
 
 static void
-mustache_error(mustache_api_t *api, void *data, uintmax_t line, char *error)
+mustache_error(mustache_api_t *api, void *data,
+               uintmax_t line, char const *error)
 {
     fprintf(stderr, "error in template: %" PRIu64  ": %s\n", line, error);
 }
@@ -53,7 +55,7 @@ mustache_varget(mustache_api_t *api, void *data, mustache_token_variable_t *t)
     static const char *name = "Angus McFife";
 
     if (strcmp(t->text, "name") == 0) {
-        api->write(api, data, (char*)name, strlen(name));
+        api->write(api, data, name, strlen(name));
         return true;
     }
 

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -30,7 +30,7 @@ typedef uintmax_t (*mustache_api_read)   (mustache_api_t *api, void *userdata, c
  * @retval 0      Error occured
  * @retval >0     Successful call
  */
-typedef uintmax_t (*mustache_api_write)  (mustache_api_t *api, void *userdata, char *buffer, uintmax_t buffer_size);
+typedef uintmax_t (*mustache_api_write)  (mustache_api_t *api, void *userdata, char const *buffer, uintmax_t buffer_size);
 
 /** Get variable callback. User call ->write api to dump variable value to output, or do nothing.
  * @param  api         Current api set
@@ -56,7 +56,7 @@ typedef uintmax_t (*mustache_api_sectget)(mustache_api_t *api, void *userdata, m
  * @param  lineno      Line number on which error occured
  * @param  error       Error description
  */
-typedef void      (*mustache_api_error)  (mustache_api_t *api, void *userdata, uintmax_t lineno, char *error); 
+typedef void      (*mustache_api_error)  (mustache_api_t *api, void *userdata, uintmax_t lineno, char const *error); 
 
 /** Free userdata callback.
  * @param  api         Current api set

--- a/src/parser.y
+++ b/src/parser.y
@@ -129,7 +129,7 @@ uintmax_t             mustache_std_strread(mustache_api_t *api, void *userdata, 
 	ctx->offset += string_len;
 	return string_len;
 } // }}}
-uintmax_t             mustache_std_strwrite(mustache_api_t *api, void *userdata, char *buffer, uintmax_t buffer_size){ // {{{
+uintmax_t             mustache_std_strwrite(mustache_api_t *api, void *userdata, char const *buffer, uintmax_t buffer_size){ // {{{
 	mustache_str_ctx      *ctx               = (mustache_str_ctx *)userdata; 
 	
 	ctx->string = realloc(ctx->string, ctx->offset + buffer_size + 1);

--- a/test/test.c
+++ b/test/test.c
@@ -23,7 +23,7 @@ uintmax_t  tests_sectget(mustache_api_t *api, void *userdata, mustache_token_sec
 	}
 	return 0; // error
 }
-void       tests_error(mustache_api_t *api, void *userdata, uintmax_t lineno, char *error){
+void       tests_error(mustache_api_t *api, void *userdata, uintmax_t lineno, char const *error){
 	fprintf(stderr, "error: %d: %s\n", (int)lineno, error);
 	error_flag = 1;
 }


### PR DESCRIPTION
The buffer of the write function should be const, as should be the error string from the error handler. This breaks API but makes the code cleaner and better. This fixes and closes #7.
