### PR TITLE
parser: Support no-escape syntax

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,8 +8,8 @@ CLEANFILES = $(GENSOURCE)
 
 include_HEADERS=mustache.h
 
-parser.tab.c: parser.lex.c
+parser.tab.c: parser.lex.c parser.y
 	${BISON} -p mustache_p_ -d -b parser parser.y
-parser.lex.c:
+parser.lex.c: parser.l
 	${FLEX}  -Pmustache_p_ --bison-bridge -o parser.lex.c parser.l
 

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -74,6 +74,7 @@ enum mustache_token_type_t {
 struct mustache_token_variable_t {
 	char                  *text;            ///< Text or variable name
 	uintmax_t              text_length;     ///< Text length or variable name length
+	int                    escaped;         ///< Whether token should be escaped
 	void                  *userdata;        ///< Userdata
 };
 

--- a/src/parser.l
+++ b/src/parser.l
@@ -27,10 +27,12 @@ special     [#^/]
 <mustag>{special}     { return *yytext; }
 <mustag>{name}        { yylval->text = strdup(yytext); return TEXT; }
 <mustag>"}}"          {	BEGIN(INITIAL); return MUSTAG_END;  }
+<mustag>"}}}"          {	BEGIN(INITIAL); return MUSTAG_NOESC_END;  }
 
 "//"+[^\n]*           {                 }
 "/*"                  { BEGIN(comment); }
 "{{"                  { BEGIN(mustag); return MUSTAG_START; }
+"{{{"                 { BEGIN(mustag); return MUSTAG_NOESC_START; }
 
 "{" |
 [^{]*                 { yylval->text = strdup(yytext); return TEXT;  }

--- a/src/parser.y
+++ b/src/parser.y
@@ -30,6 +30,10 @@ void yyerror (mustache_ctx *, const char *);
 }
 %token TEXT MUSTAG_START MUSTAG_END
 %type  <text>                  TEXT MUSTAG_START MUSTAG_END text
+
+%token MUSTAG_NOESC_START "{{{"
+%token MUSTAG_NOESC_END "}}}"
+
 %type  <template>              tpl_tokens
 %type  <template>              tpl_token
 
@@ -61,6 +65,16 @@ tpl_token :
 		$$->type                     = TOKEN_TEXT;
 		$$->token_simple.text        = $1;
 		$$->token_simple.text_length = strlen($1);
+		$$->token_simple.escaped     = 1;
+		$$->token_simple.userdata    = NULL;
+		$$->next                     = NULL;
+	}
+	| MUSTAG_NOESC_START text MUSTAG_NOESC_END {         // mustache escaped tag
+		$$ = malloc(sizeof(mustache_token_t));
+		$$->type                     = TOKEN_VARIABLE;
+		$$->token_simple.text        = $2;
+		$$->token_simple.text_length = strlen($2);
+		$$->token_simple.escaped     = 0;
 		$$->token_simple.userdata    = NULL;
 		$$->next                     = NULL;
 	}
@@ -69,6 +83,7 @@ tpl_token :
 		$$->type                     = TOKEN_VARIABLE;
 		$$->token_simple.text        = $2;
 		$$->token_simple.text_length = strlen($2);
+		$$->token_simple.escaped     = 0;
 		$$->token_simple.userdata    = NULL;
 		$$->next                     = NULL;
 	}


### PR DESCRIPTION
By default, HTML inside of {{ and }} should be escaped, but if
it is inside triple-brackets, it should be left alone, according
to the spec: https://mustache.github.io/mustache.5.html

It is the responsibility of the implementer to implement escaping.
All mustache_c does is set the 'escaped' field on the struct to
1 if escaping should be used.