### PR TITLE
parser: Fix memory leak in parsing sections

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -95,6 +95,10 @@ tpl_token :
 		$$->token_section.inverted = 0;
 		$$->token_section.userdata = NULL;
 		$$->next                   = NULL;
+
+		// We don't need the closing tag name and it was strdup'd earlier,
+		// free it now.
+		free($8);
 	}
 	| MUSTAG_START '^' text MUSTAG_END tpl_tokens MUSTAG_START '/' text MUSTAG_END { // mustache inverted section 
 		$$ = malloc(sizeof(mustache_token_t));
@@ -104,6 +108,10 @@ tpl_token :
 		$$->token_section.inverted = 1;
 		$$->token_section.userdata = NULL;
 		$$->next                   = NULL;
+
+		// We don't need the closing tag name and it was strdup'd earlier,
+		// free it now.
+		free($8);
 	}
 	;
 


### PR DESCRIPTION
When we parse a token, we call strdup() on it in parser.l. In most
cases this is freed by mustache_free, but when parsing sections
we don't store the value of the closing tag name so the memory
reference gets lost. Because we don't use it anyway, it should
just be freed once we've finished building up that mustache_token_t.