### PR TITLE
feat: allow allocator customization at runtime

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
 GENSOURCE = parser.tab.h parser.tab.c parser.lex.c
 
 lib_LTLIBRARIES=libmustache_c.la
-libmustache_c_la_SOURCES= $(GENSOURCE) mustache-internal.h
+libmustache_c_la_SOURCES= $(GENSOURCE) mustache-internal.h mustache.c
 libmustache_c_la_LDFLAGS= -module -avoid-version -shared
-EXTRA_DIST = parser.l parser.y                 
+EXTRA_DIST = parser.l parser.y
 CLEANFILES = $(GENSOURCE)
 
 include_HEADERS=mustache.h

--- a/src/mustache-internal.h
+++ b/src/mustache-internal.h
@@ -7,4 +7,14 @@ typedef struct mustache_ctx {
 	void                  *userdata;
 } mustache_ctx;
 
+void *internal_mustache_malloc(size_t size);
+
+void *internal_mustache_realloc(void *dst, size_t size);
+
+void *internal_mustache_calloc(size_t num, size_t size);
+
+void *internal_mustache_free(void *dst);
+
+char *mustache_strdup(const char *src);
+
 #endif

--- a/src/mustache.c
+++ b/src/mustache.c
@@ -1,0 +1,53 @@
+#include <stdlib.h>
+#include <string.h>
+#include "mustache.h"
+#include "mustache-internal.h"
+
+static mustache_memory_malloc_f mustache_memory_malloc = malloc;
+static mustache_memory_realloc_f mustache_memory_realloc = realloc;
+static mustache_memory_calloc_f mustache_memory_calloc = calloc;
+static mustache_memory_free_f mustache_memory_free = free;
+
+// explicit strdup that doesn't hide malloc
+char *mustache_strdup(const char *src) {
+	size_t len = strlen(src) + 1;
+	char *s = internal_mustache_malloc(len);
+	if (s == NULL)
+		return NULL;
+	return (char *)memcpy(s, src, len);
+}
+
+void *
+internal_mustache_malloc(size_t size)
+{
+    return mustache_memory_malloc(size);
+}
+
+void *
+internal_mustache_realloc(void *dst, size_t size)
+{
+    return mustache_memory_realloc(dst, size);
+}
+
+void *
+internal_mustache_calloc(size_t num, size_t size)
+{
+    return mustache_memory_calloc(num, size);
+}
+
+void *
+internal_mustache_free(void *dst)
+{
+    mustache_memory_free(dst);
+    return NULL;
+}
+
+void
+mustache_memory_setup(mustache_memory_malloc_f new_malloc, mustache_memory_realloc_f new_realloc,
+                    mustache_memory_calloc_f new_calloc, mustache_memory_free_f new_free)
+{
+    mustache_memory_malloc = new_malloc;
+    mustache_memory_realloc = new_realloc;
+    mustache_memory_calloc = new_calloc;
+    mustache_memory_free = new_free;
+}

--- a/src/mustache.h
+++ b/src/mustache.h
@@ -152,4 +152,13 @@ uintmax_t             mustache_std_strwrite (mustache_api_t *api, void *userdata
 // debug api (build with --enable-debug, not default)
 void                  mustache_dump   (mustache_template_t *template); ///< Debug dump template
 
+typedef void *(*mustache_memory_malloc_f)(size_t size);
+typedef void *(*mustache_memory_realloc_f)(void *dst, size_t size);
+typedef void *(*mustache_memory_calloc_f)(size_t num, size_t size);
+typedef void (*mustache_memory_free_f)(void *dst);
+
+void
+mustache_memory_setup(mustache_memory_malloc_f new_malloc, mustache_memory_realloc_f new_realloc,
+                    mustache_memory_calloc_f new_calloc, mustache_memory_free_f new_free);
+
 #endif

--- a/src/parser.l
+++ b/src/parser.l
@@ -25,9 +25,9 @@ special     [#^/]
 <comment>"*"+"/"        BEGIN(INITIAL);
 
 <mustag>{special}     { return *yytext; }
-<mustag>{name}        { yylval->text = strdup(yytext); return TEXT; }
-<mustag>"}}"          {	BEGIN(INITIAL); return MUSTAG_END;  }
-<mustag>"}}}"          {	BEGIN(INITIAL); return MUSTAG_NOESC_END;  }
+<mustag>{name}        { yylval->text = mustache_strdup(yytext); return TEXT; }
+<mustag>"}}"          { BEGIN(INITIAL); return MUSTAG_END;  }
+<mustag>"}}}"         { BEGIN(INITIAL); return MUSTAG_NOESC_END;  }
 
 "//"+[^\n]*           {                 }
 "/*"                  { BEGIN(comment); }
@@ -35,7 +35,6 @@ special     [#^/]
 "{{{"                 { BEGIN(mustag); return MUSTAG_NOESC_START; }
 
 "{" |
-[^{]*                 { yylval->text = strdup(yytext); return TEXT;  }
+[^{]*                 { yylval->text = mustache_strdup(yytext); return TEXT;  }
 
 %%
-

--- a/src/parser.y
+++ b/src/parser.y
@@ -6,7 +6,7 @@
 #include <config.h>
 #include <mustache.h>
 #include <mustache-internal.h>
-#include <parser.tab.h>	
+#include <parser.tab.h>
 
 #define YY_END_OF_BUFFER_CHAR 0
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
@@ -50,10 +50,10 @@ tpl_tokens :
 	}
 	| tpl_tokens tpl_token {
 		mustache_token_t *p = $1;
-		
+
 		while(p->next != NULL)
 			p = p->next;
-		
+
 		p->next = $2;
 		$$ = $1;
 	}
@@ -61,7 +61,7 @@ tpl_tokens :
 
 tpl_token :
 	text {                                   // simple text
-		$$ = malloc(sizeof(mustache_token_t));
+		$$ = internal_mustache_malloc(sizeof(mustache_token_t));
 		$$->type                     = TOKEN_TEXT;
 		$$->token_simple.text        = $1;
 		$$->token_simple.text_length = strlen($1);
@@ -70,7 +70,7 @@ tpl_token :
 		$$->next                     = NULL;
 	}
 	| MUSTAG_NOESC_START text MUSTAG_NOESC_END {         // mustache escaped tag
-		$$ = malloc(sizeof(mustache_token_t));
+		$$ = internal_mustache_malloc(sizeof(mustache_token_t));
 		$$->type                     = TOKEN_VARIABLE;
 		$$->token_simple.text        = $2;
 		$$->token_simple.text_length = strlen($2);
@@ -79,7 +79,7 @@ tpl_token :
 		$$->next                     = NULL;
 	}
 	| MUSTAG_START text MUSTAG_END {         // mustache tag
-		$$ = malloc(sizeof(mustache_token_t));
+		$$ = internal_mustache_malloc(sizeof(mustache_token_t));
 		$$->type                     = TOKEN_VARIABLE;
 		$$->token_simple.text        = $2;
 		$$->token_simple.text_length = strlen($2);
@@ -88,7 +88,7 @@ tpl_token :
 		$$->next                     = NULL;
 	}
 	| MUSTAG_START '#' text MUSTAG_END tpl_tokens MUSTAG_START '/' text MUSTAG_END { // mustache section
-		$$ = malloc(sizeof(mustache_token_t));
+		$$ = internal_mustache_malloc(sizeof(mustache_token_t));
 		$$->type                   = TOKEN_SECTION;
 		$$->token_section.name     = $3;
 		$$->token_section.section  = $5;
@@ -98,10 +98,10 @@ tpl_token :
 
 		// We don't need the closing tag name and it was strdup'd earlier,
 		// free it now.
-		free($8);
+		internal_mustache_free($8);
 	}
-	| MUSTAG_START '^' text MUSTAG_END tpl_tokens MUSTAG_START '/' text MUSTAG_END { // mustache inverted section 
-		$$ = malloc(sizeof(mustache_token_t));
+	| MUSTAG_START '^' text MUSTAG_END tpl_tokens MUSTAG_START '/' text MUSTAG_END { // mustache inverted section
+		$$ = internal_mustache_malloc(sizeof(mustache_token_t));
 		$$->type                   = TOKEN_SECTION;
 		$$->token_section.name     = $3;
 		$$->token_section.section  = $5;
@@ -111,7 +111,7 @@ tpl_token :
 
 		// We don't need the closing tag name and it was strdup'd earlier,
 		// free it now.
-		free($8);
+		internal_mustache_free($8);
 	}
 	;
 
@@ -121,14 +121,14 @@ text :
 	}
 	| text TEXT {    // eat up text duplicates
 		uintmax_t len1, len2;
-		
+
 		len1 = strlen($1);
 		len2 = strlen($2);
-		$1   = realloc($1, len1 + len2 + 1);
+		$1   = internal_mustache_realloc($1, len1 + len2 + 1);
 		memcpy($1 + len1, $2, len2 + 1);
-		
+
 		$$  = $1;
-		free($2);
+		internal_mustache_free($2);
 	}
 
 %%
@@ -141,25 +141,25 @@ void yyerror(mustache_ctx *ctx, const char *msg){ // {{{
 uintmax_t             mustache_std_strread(mustache_api_t *api, void *userdata, char *buffer, uintmax_t buffer_size){ // {{{
 	char                  *string;
 	uintmax_t              string_len;
-	mustache_str_ctx      *ctx               = (mustache_str_ctx *)userdata; 
-	
+	mustache_str_ctx      *ctx               = (mustache_str_ctx *)userdata;
+
 	string     = ctx->string + ctx->offset;
 	string_len = strlen(string);
 	string_len = (string_len < buffer_size) ? string_len : buffer_size;
-	
+
 	memcpy(buffer, string, string_len);
-	
+
 	ctx->offset += string_len;
 	return string_len;
 } // }}}
 uintmax_t             mustache_std_strwrite(mustache_api_t *api, void *userdata, char const *buffer, uintmax_t buffer_size){ // {{{
-	mustache_str_ctx      *ctx               = (mustache_str_ctx *)userdata; 
-	
-	ctx->string = realloc(ctx->string, ctx->offset + buffer_size + 1);
-	
+	mustache_str_ctx      *ctx               = (mustache_str_ctx *)userdata;
+
+	ctx->string = internal_mustache_realloc(ctx->string, ctx->offset + buffer_size + 1);
+
 	memcpy(ctx->string + ctx->offset, buffer, buffer_size);
 	ctx->string[ctx->offset + buffer_size] = '\0';
-	
+
 	ctx->offset += buffer_size;
 	return buffer_size;
 } // }}}
@@ -170,33 +170,33 @@ mustache_template_t * mustache_compile(mustache_api_t *api, void *userdata){ // 
 	char                  *content           = NULL;
 	uintmax_t              content_off       = 0;
 	uintmax_t              ret;
-	
+
 	while(1){
-		content       = realloc(content, content_off + 1024 + 2); // 2 for terminating EOF of yy
+		content       = internal_mustache_realloc(content, content_off + 1024 + 2); // 2 for terminating EOF of yy
 		if(!content)
 			break;
-		
+
 		if( (ret = api->read(api, userdata, content + content_off, 1024)) == 0)
 			break;
-		
+
 		content_off += ret;
 	}
-	
+
 	if(content){
 		content[content_off] = content[content_off+1] = YY_END_OF_BUFFER_CHAR;
-		
+
 		mustache_p__scan_buffer(content, content_off + 2);
-		
+
 		yyparse(&ctx);
-		
+
 		mustache_p_lex_destroy();
-		free(content);
+		internal_mustache_free(content);
 	}
 	return ctx.template;
 } // }}}
 uintmax_t             mustache_prerender (mustache_api_t *api, void *userdata, mustache_template_t *template){ // {{{
 	mustache_template_t            *p;
-	
+
 	for(p = template; p; p = p->next){
 		switch(p->type){
 			case TOKEN_TEXT:
@@ -215,7 +215,7 @@ uintmax_t             mustache_prerender (mustache_api_t *api, void *userdata, m
 } // }}}
 uintmax_t             mustache_render (mustache_api_t *api, void *userdata, mustache_template_t *template){ // {{{
 	mustache_template_t            *p;
-	
+
 	for(p = template; p; p = p->next){
 		switch(p->type){
 			case TOKEN_TEXT:
@@ -236,28 +236,28 @@ uintmax_t             mustache_render (mustache_api_t *api, void *userdata, must
 } // }}}
 void                  mustache_free   (mustache_api_t *api, mustache_template_t *template){ // {{{
 	mustache_template_t            *p, *n;
-	
+
 	for(p = template; p; p = n){
 		switch(p->type){
 			case TOKEN_TEXT:
 			case TOKEN_VARIABLE:
 				if(p->token_simple.userdata && api->freedata)
 					api->freedata(api, p->token_simple.userdata);
-				
+
 				if(p->token_simple.text)
-					free(p->token_simple.text);
+					internal_mustache_free(p->token_simple.text);
 				break;
 			case TOKEN_SECTION:
 				if(p->token_section.userdata && api->freedata)
 					api->freedata(api, p->token_section.userdata);
-				
+
 				mustache_free(api, p->token_section.section);
 				if(p->token_section.name)
-					free(p->token_section.name);
+					internal_mustache_free(p->token_section.name);
 				break;
 		};
 		n = p->next;
-		free(p);
+		internal_mustache_free(p);
 	}
 } // }}}
 
@@ -270,7 +270,7 @@ char * token_descr[] = {
 
 void mustache_dump(mustache_template_t *template){ // {{{
 	mustache_template_t            *p;
-	
+
 	p = template;
 	do{
 		fprintf(stderr, "token: ->type '%s'; ->text: '%s'; ->next = %p\n",


### PR DESCRIPTION
This adds a `mustache_memory_setup` function that can be used for custom memory allocators like so:

```c
mustache_memory_setup(palloc, repalloc, palloc0, pfree);
```

The main motivation is to be able to use mustache-c in postgresql extensions. But this can be used in other ways too, like leak checking with the Boehm GC.

This is completely optional and doesn't cause API breakage. `mustache-c` keeps using the standard malloc, realloc and free by default.

---

Note: Some whitespaces were deleted by my Vim config (maybe not a bad thing).

@x86-64 Let me know your thoughts. Thanks!